### PR TITLE
reducir triggers y cambiar funciones

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -4,6 +4,6 @@
     <file url="file://$PROJECT_DIR$/movimientos.sql" dialect="GenericSQL" />
     <file url="file://$PROJECT_DIR$/mysql_sentencias.sql" dialect="MySQL" />
     <file url="file://$PROJECT_DIR$/postgres_sentencias.sql" dialect="PostgreSQL" />
-    <file url="PROJECT" dialect="MySQL" />
+    <file url="PROJECT" dialect="PostgreSQL" />
   </component>
 </project>


### PR DESCRIPTION
Realicé cambios en la estructura del archivo de postgres, principalmente en los triggers y funciones:
Ahora con úna unica función se pueden añadir a la bitácora las inserciones, modificiaciones y eliminaciones (ojo, eliminaciones efectivas, no he probado si intentos también se puedan)  en las 3 tablas correspondientes, además de reducir los triggers para que en 1 solo se puedan implementar para los 3 casos de uso